### PR TITLE
Add platinum licensing check to Meta Engines table/call

### DIFF
--- a/x-pack/plugins/enterprise_search/kibana.json
+++ b/x-pack/plugins/enterprise_search/kibana.json
@@ -2,7 +2,7 @@
   "id": "enterpriseSearch",
   "version": "1.0.0",
   "kibanaVersion": "kibana",
-  "requiredPlugins": ["home"],
+  "requiredPlugins": ["home", "licensing"],
   "configPath": ["enterpriseSearch"],
   "optionalPlugins": ["usageCollection"],
   "server": true,

--- a/x-pack/plugins/enterprise_search/public/applications/__mocks__/index.ts
+++ b/x-pack/plugins/enterprise_search/public/applications/__mocks__/index.ts
@@ -6,6 +6,7 @@
 
 export { mockHistory } from './react_router_history.mock';
 export { mockKibanaContext } from './kibana_context.mock';
+export { mockLicenseContext } from './license_context.mock';
 export { mountWithKibanaContext } from './mount_with_context.mock';
 
 // Note: shallow_usecontext must be imported directly as a file

--- a/x-pack/plugins/enterprise_search/public/applications/__mocks__/kibana_context.mock.ts
+++ b/x-pack/plugins/enterprise_search/public/applications/__mocks__/kibana_context.mock.ts
@@ -14,4 +14,5 @@ export const mockKibanaContext = {
   http: httpServiceMock.createSetupContract(),
   setBreadcrumbs: jest.fn(),
   enterpriseSearchUrl: 'http://localhost:3002',
+  license$: jest.fn(),
 };

--- a/x-pack/plugins/enterprise_search/public/applications/__mocks__/license_context.mock.ts
+++ b/x-pack/plugins/enterprise_search/public/applications/__mocks__/license_context.mock.ts
@@ -1,0 +1,11 @@
+/*
+ * Copyright Elasticsearch B.V. and/or licensed to Elasticsearch B.V. under one
+ * or more contributor license agreements. Licensed under the Elastic License;
+ * you may not use this file except in compliance with the Elastic License.
+ */
+
+import { licensingMock } from '../../../../licensing/public/mocks';
+
+export const mockLicenseContext = {
+  license: licensingMock.createLicense(),
+};

--- a/x-pack/plugins/enterprise_search/public/applications/__mocks__/shallow_usecontext.mock.ts
+++ b/x-pack/plugins/enterprise_search/public/applications/__mocks__/shallow_usecontext.mock.ts
@@ -5,14 +5,15 @@
  */
 
 /**
- * NOTE: This variable name MUST start with 'mock*' in order for
+ * NOTE: These variable names MUST start with 'mock*' in order for
  * Jest to accept its use within a jest.mock()
  */
 import { mockKibanaContext } from './kibana_context.mock';
+import { mockLicenseContext } from './license_context.mock';
 
 jest.mock('react', () => ({
   ...jest.requireActual('react'),
-  useContext: jest.fn(() => mockKibanaContext),
+  useContext: jest.fn(() => ({ ...mockKibanaContext, ...mockLicenseContext })),
 }));
 
 /**

--- a/x-pack/plugins/enterprise_search/public/applications/app_search/components/engine_overview/engine_overview.tsx
+++ b/x-pack/plugins/enterprise_search/public/applications/app_search/components/engine_overview/engine_overview.tsx
@@ -17,6 +17,7 @@ import {
 
 import { SetAppSearchBreadcrumbs as SetBreadcrumbs } from '../../../shared/kibana_breadcrumbs';
 import { SendAppSearchTelemetry as SendTelemetry } from '../../../shared/telemetry';
+import { LicenseContext, ILicenseContext, hasPlatinumLicense } from '../../../shared/licensing';
 import { KibanaContext, IKibanaContext } from '../../../index';
 
 import EnginesIcon from '../../assets/engine.svg';
@@ -30,6 +31,7 @@ import './engine_overview.scss';
 
 export const EngineOverview: ReactFC<> = () => {
   const { http } = useContext(KibanaContext) as IKibanaContext;
+  const { license } = useContext(LicenseContext) as ILicenseContext;
 
   const [isLoading, setIsLoading] = useState(true);
   const [hasNoAccount, setHasNoAccount] = useState(false);
@@ -72,11 +74,13 @@ export const EngineOverview: ReactFC<> = () => {
   }, [enginesPage]); // eslint-disable-line react-hooks/exhaustive-deps
 
   useEffect(() => {
-    const params = { type: 'meta', pageIndex: metaEnginesPage };
-    const callbacks = { setResults: setMetaEngines, setResultsTotal: setMetaEnginesTotal };
+    if (hasPlatinumLicense(license)) {
+      const params = { type: 'meta', pageIndex: metaEnginesPage };
+      const callbacks = { setResults: setMetaEngines, setResultsTotal: setMetaEnginesTotal };
 
-    setEnginesData(params, callbacks);
-  }, [metaEnginesPage]); // eslint-disable-line react-hooks/exhaustive-deps
+      setEnginesData(params, callbacks);
+    }
+  }, [license, metaEnginesPage]); // eslint-disable-line react-hooks/exhaustive-deps
 
   if (hasErrorConnecting) return <ErrorState />;
   if (hasNoAccount) return <NoUserState />;

--- a/x-pack/plugins/enterprise_search/public/applications/index.test.ts
+++ b/x-pack/plugins/enterprise_search/public/applications/index.test.ts
@@ -5,14 +5,20 @@
  */
 
 import { coreMock } from 'src/core/public/mocks';
-import { renderApp } from '../applications';
+import { licensingMock } from '../../../licensing/public/mocks';
+
+import { renderApp } from './';
 
 describe('renderApp', () => {
   it('mounts and unmounts UI', () => {
     const params = coreMock.createAppMountParamters();
     const core = coreMock.createStart();
+    const config = {};
+    const plugins = {
+      licensing: licensingMock.createSetup(),
+    };
 
-    const unmount = renderApp(core, params, {});
+    const unmount = renderApp(core, params, config, plugins);
     expect(params.element.querySelector('.setup-guide')).not.toBeNull();
     unmount();
     expect(params.element.innerHTML).toEqual('');

--- a/x-pack/plugins/enterprise_search/public/applications/index.tsx
+++ b/x-pack/plugins/enterprise_search/public/applications/index.tsx
@@ -9,7 +9,7 @@ import ReactDOM from 'react-dom';
 import { BrowserRouter, Route, Redirect } from 'react-router-dom';
 
 import { CoreStart, AppMountParams, HttpHandler } from 'src/core/public';
-import { ClientConfigType } from '../plugin';
+import { ClientConfigType, PluginsSetup } from '../plugin';
 import { TSetBreadcrumbs } from './shared/kibana_breadcrumbs';
 
 import { AppSearch } from './app_search';
@@ -22,7 +22,12 @@ export interface IKibanaContext {
 
 export const KibanaContext = React.createContext();
 
-export const renderApp = (core: CoreStart, params: AppMountParams, config: ClientConfigType) => {
+export const renderApp = (
+  core: CoreStart,
+  params: AppMountParams,
+  config: ClientConfigType,
+  plugins: PluginsSetup
+) => {
   ReactDOM.render(
     <KibanaContext.Provider
       value={{

--- a/x-pack/plugins/enterprise_search/public/applications/index.tsx
+++ b/x-pack/plugins/enterprise_search/public/applications/index.tsx
@@ -11,6 +11,8 @@ import { BrowserRouter, Route, Redirect } from 'react-router-dom';
 import { CoreStart, AppMountParams, HttpHandler } from 'src/core/public';
 import { ClientConfigType, PluginsSetup } from '../plugin';
 import { TSetBreadcrumbs } from './shared/kibana_breadcrumbs';
+import { ILicense } from '../../../../licensing/public';
+import { LicenseProvider } from './shared/licensing';
 
 import { AppSearch } from './app_search';
 
@@ -18,6 +20,7 @@ export interface IKibanaContext {
   enterpriseSearchUrl?: string;
   http(): HttpHandler;
   setBreadCrumbs(): TSetBreadcrumbs;
+  license$: Observable<ILicense>;
 }
 
 export const KibanaContext = React.createContext();
@@ -34,18 +37,21 @@ export const renderApp = (
         http: core.http,
         enterpriseSearchUrl: config.host,
         setBreadcrumbs: core.chrome.setBreadcrumbs,
+        license$: plugins.licensing.license$,
       }}
     >
-      <BrowserRouter basename={params.appBasePath}>
-        <Route exact path="/">
-          {/* This will eventually contain an Enterprise Search landing page,
-          and we'll also actually have a /workplace_search route */}
-          <Redirect to="/app_search" />
-        </Route>
-        <Route path="/app_search">
-          <AppSearch />
-        </Route>
-      </BrowserRouter>
+      <LicenseProvider>
+        <BrowserRouter basename={params.appBasePath}>
+          <Route exact path="/">
+            {/* This will eventually contain an Enterprise Search landing page,
+            and we'll also actually have a /workplace_search route */}
+            <Redirect to="/app_search" />
+          </Route>
+          <Route path="/app_search">
+            <AppSearch />
+          </Route>
+        </BrowserRouter>
+      </LicenseProvider>
     </KibanaContext.Provider>,
     params.element
   );

--- a/x-pack/plugins/enterprise_search/public/applications/shared/licensing/index.ts
+++ b/x-pack/plugins/enterprise_search/public/applications/shared/licensing/index.ts
@@ -1,0 +1,7 @@
+/*
+ * Copyright Elasticsearch B.V. and/or licensed to Elasticsearch B.V. under one
+ * or more contributor license agreements. Licensed under the Elastic License;
+ * you may not use this file except in compliance with the Elastic License.
+ */
+
+export { LicenseContext, LicenseProvider, ILicenseContext } from './license_context';

--- a/x-pack/plugins/enterprise_search/public/applications/shared/licensing/license_checks.test.ts
+++ b/x-pack/plugins/enterprise_search/public/applications/shared/licensing/license_checks.test.ts
@@ -1,0 +1,33 @@
+/*
+ * Copyright Elasticsearch B.V. and/or licensed to Elasticsearch B.V. under one
+ * or more contributor license agreements. Licensed under the Elastic License;
+ * you may not use this file except in compliance with the Elastic License.
+ */
+
+import { hasPlatinumLicense } from './license_checks';
+
+describe('hasPlatinumLicense', () => {
+  it('is true for platinum licenses', () => {
+    expect(hasPlatinumLicense({ isActive: true, type: 'platinum' })).toEqual(true);
+  });
+
+  it('is true for enterprise licenses', () => {
+    expect(hasPlatinumLicense({ isActive: true, type: 'enterprise' })).toEqual(true);
+  });
+
+  it('is true for trial licenses', () => {
+    expect(hasPlatinumLicense({ isActive: true, type: 'platinum' })).toEqual(true);
+  });
+
+  it('is false if the current license is expired', () => {
+    expect(hasPlatinumLicense({ isActive: false, type: 'platinum' })).toEqual(false);
+    expect(hasPlatinumLicense({ isActive: false, type: 'enterprise' })).toEqual(false);
+    expect(hasPlatinumLicense({ isActive: false, type: 'trial' })).toEqual(false);
+  });
+
+  it('is false for licenses below platinum', () => {
+    expect(hasPlatinumLicense({ isActive: true, type: 'basic' })).toEqual(false);
+    expect(hasPlatinumLicense({ isActive: false, type: 'standard' })).toEqual(false);
+    expect(hasPlatinumLicense({ isActive: true, type: 'gold' })).toEqual(false);
+  });
+});

--- a/x-pack/plugins/enterprise_search/public/applications/shared/licensing/license_checks.ts
+++ b/x-pack/plugins/enterprise_search/public/applications/shared/licensing/license_checks.ts
@@ -4,5 +4,8 @@
  * you may not use this file except in compliance with the Elastic License.
  */
 
-export { LicenseContext, LicenseProvider, ILicenseContext } from './license_context';
-export { hasPlatinumLicense } from './license_checks';
+import { ILicense } from '../../../../../../licensing/public';
+
+export const hasPlatinumLicense = (license: ILicenseContext) => {
+  return license?.isActive && ['platinum', 'enterprise', 'trial'].includes(license?.type);
+};

--- a/x-pack/plugins/enterprise_search/public/applications/shared/licensing/license_context.test.tsx
+++ b/x-pack/plugins/enterprise_search/public/applications/shared/licensing/license_context.test.tsx
@@ -1,0 +1,28 @@
+/*
+ * Copyright Elasticsearch B.V. and/or licensed to Elasticsearch B.V. under one
+ * or more contributor license agreements. Licensed under the Elastic License;
+ * you may not use this file except in compliance with the Elastic License.
+ */
+
+import React, { useContext } from 'react';
+
+import { mountWithKibanaContext } from '../../__mocks__';
+import { LicenseContext, ILicenseContext } from './';
+
+describe('LicenseProvider', () => {
+  const MockComponent: React.FC<> = () => {
+    const { license } = useContext(LicenseContext) as ILicenseContext;
+    return <div className="license-test">{license.type}</div>;
+  };
+
+  it('renders children', () => {
+    const wrapper = mountWithKibanaContext(
+      <LicenseContext.Provider value={{ license: { type: 'basic' } }}>
+        <MockComponent />
+      </LicenseContext.Provider>
+    );
+
+    expect(wrapper.find('.license-test')).toHaveLength(1);
+    expect(wrapper.text()).toEqual('basic');
+  });
+});

--- a/x-pack/plugins/enterprise_search/public/applications/shared/licensing/license_context.tsx
+++ b/x-pack/plugins/enterprise_search/public/applications/shared/licensing/license_context.tsx
@@ -1,0 +1,27 @@
+/*
+ * Copyright Elasticsearch B.V. and/or licensed to Elasticsearch B.V. under one
+ * or more contributor license agreements. Licensed under the Elastic License;
+ * you may not use this file except in compliance with the Elastic License.
+ */
+
+import React, { useContext } from 'react';
+import useObservable from 'react-use/lib/useObservable';
+
+import { KibanaContext, IKibanaContext } from '../../';
+
+import { ILicense } from '../../../../licensing/public';
+
+export interface ILicenseContext {
+  license?: ILicense;
+}
+
+export const LicenseContext = React.createContext();
+
+export const LicenseProvider: React.FC<> = ({ children }) => {
+  // Listen for changes to license subscription
+  const { license$ } = useContext(KibanaContext) as IKibanaContext;
+  const license = useObservable(license$);
+
+  // Render rest of application and pass down license via context
+  return <LicenseContext.Provider value={{ license }} children={children} />;
+};

--- a/x-pack/plugins/enterprise_search/public/plugin.ts
+++ b/x-pack/plugins/enterprise_search/public/plugin.ts
@@ -17,6 +17,7 @@ import {
   HomePublicPluginSetup,
 } from '../../../../src/plugins/home/public';
 import { DEFAULT_APP_CATEGORIES } from '../../../../src/core/public';
+import { LicensingPluginSetup } from '../../licensing/public';
 
 import AppSearchLogo from './applications/app_search/assets/logo.svg';
 
@@ -24,7 +25,8 @@ export interface ClientConfigType {
   host?: string;
 }
 export interface PluginsSetup {
-  home?: HomePublicPluginSetup;
+  home: HomePublicPluginSetup;
+  licensing: LicensingPluginSetup;
 }
 
 export class EnterpriseSearchPlugin implements Plugin {
@@ -43,11 +45,12 @@ export class EnterpriseSearchPlugin implements Plugin {
       euiIconType: AppSearchLogo, // TODO: Temporary - App Search will likely no longer need an icon once the nav structure changes.
       category: DEFAULT_APP_CATEGORIES.management, // TODO - This is likely not final/correct
       order: 10, // TODO - This will also likely not be needed once new nav structure changes land
-      async mount(params: AppMountParameters) {
+      mount: async (params: AppMountParameters) => {
         const [coreStart] = await core.getStartServices();
+
         const { renderApp } = await import('./applications');
 
-        return renderApp(coreStart, params, config);
+        return renderApp(coreStart, params, config, plugins);
       },
     });
 


### PR DESCRIPTION
## Description

Per @JasonStoltz's excellent catch in https://github.com/elastic/app-search-team/issues/716#issuecomment-624783984, we should follow App Search's current behavior and not display meta engines in the UI if the user is not on the platinum plan or their platinum plan has expired.

[I strongly recommend following along by-commit](https://github.com/constancecchen/kibana/pull/11/commits) for ease of understanding - I ran around in circles a good amount implementing this so I can only imagine it's worse for someone else who hasn't been staring at Kibana code for hours. :)

### Licensing plugin resources

- https://github.com/elastic/kibana/blob/master/x-pack/plugins/licensing/README.md
- https://github.com/elastic/kibana/blob/master/src/core/MIGRATION_EXAMPLES.md#migrating-hapi-pre-handlers

## Acceptance criteria

- View the plugin on a Basic license
  - [x] Confirm the XHR call to `api/app_search/engines?type=meta&pageIndex=1` never gets made
- View the plugin on a Basic license, then start a Trial license in a separate window (by going to `localhost:3002/ent/select` and starting a Workplace Search trial)
  - [x] Confirm an XHR call to `api/app_search/engines?type=meta&pageIndex=1` gets made in the original Kibana window **without** refreshing the page (this may take a while to show up, the polling duration for the license observable seems to be 1-5min+)
- View the plugin with a platinum license and an AS account that has meta engines
  - [x] Confirm the meta engines table shows up as expected
- View the plugin with an **expired** platinum license and an AS account that has meta engines
  - [x] Confirm the meta engines table **do not** show up