### PR TITLE
Add i18n formatted messages / translations

### DIFF
--- a/x-pack/plugins/enterprise_search/public/applications/__mocks__/index.ts
+++ b/x-pack/plugins/enterprise_search/public/applications/__mocks__/index.ts
@@ -7,6 +7,7 @@
 export { mockHistory } from './react_router_history.mock';
 export { mockKibanaContext } from './kibana_context.mock';
 export { mockLicenseContext } from './license_context.mock';
-export { mountWithKibanaContext } from './mount_with_context.mock';
+export { mountWithContext, mountWithKibanaContext } from './mount_with_context.mock';
+export { shallowWithIntl } from './shallow_with_i18n.mock';
 
 // Note: shallow_usecontext must be imported directly as a file

--- a/x-pack/plugins/enterprise_search/public/applications/__mocks__/mount_with_context.mock.tsx
+++ b/x-pack/plugins/enterprise_search/public/applications/__mocks__/mount_with_context.mock.tsx
@@ -7,21 +7,43 @@
 import React from 'react';
 import { mount } from 'enzyme';
 
+import { I18nProvider } from '@kbn/i18n/react';
 import { KibanaContext } from '../';
 import { mockKibanaContext } from './kibana_context.mock';
+import { LicenseContext } from '../shared/licensing';
+import { mockLicenseContext } from './license_context.mock';
 
 /**
- * This helper mounts a component with a set of default KibanaContext,
- * while also allowing custom context to be passed in via a second arg
+ * This helper mounts a component with all the contexts/providers used
+ * by the production app, while allowing custom context to be
+ * passed in via a second arg
  *
  * Example usage:
  *
- * const wrapper = mountWithKibanaContext(<Component />, { enterpriseSearchUrl: 'someOverride' });
+ * const wrapper = mountWithContext(<Component />, { enterpriseSearchUrl: 'someOverride', license: {} });
  */
-export const mountWithKibanaContext = (node, contextProps) => {
+export const mountWithContext = (children, context) => {
   return mount(
-    <KibanaContext.Provider value={{ ...mockKibanaContext, ...contextProps }}>
-      {node}
+    <I18nProvider>
+      <KibanaContext.Provider value={{ ...mockKibanaContext, ...context }}>
+        <LicenseContext.Provider value={{ ...mockLicenseContext, ...context }}>
+          {children}
+        </LicenseContext.Provider>
+      </KibanaContext.Provider>
+    </I18nProvider>
+  );
+};
+
+/**
+ * This helper mounts a component with just the default KibanaContext -
+ * useful for isolated / helper components that only need this context
+ *
+ * Same usage/override functionality as mountWithContext
+ */
+export const mountWithKibanaContext = (children, context) => {
+  return mount(
+    <KibanaContext.Provider value={{ ...mockKibanaContext, ...context }}>
+      {children}
     </KibanaContext.Provider>
   );
 };

--- a/x-pack/plugins/enterprise_search/public/applications/__mocks__/shallow_with_i18n.mock.tsx
+++ b/x-pack/plugins/enterprise_search/public/applications/__mocks__/shallow_with_i18n.mock.tsx
@@ -1,0 +1,31 @@
+/*
+ * Copyright Elasticsearch B.V. and/or licensed to Elasticsearch B.V. under one
+ * or more contributor license agreements. Licensed under the Elastic License;
+ * you may not use this file except in compliance with the Elastic License.
+ */
+
+import React from 'react';
+import { shallow } from 'enzyme';
+import { I18nProvider } from '@kbn/i18n/react';
+import { IntlProvider } from 'react-intl';
+
+const intlProvider = new IntlProvider({ locale: 'en', messages: {} }, {});
+const { intl } = intlProvider.getChildContext();
+
+/**
+ * This helper shallow wraps a component with react-intl's <I18nProvider> which
+ * fixes "Could not find required `intl` object" console errors when running tests
+ *
+ * Example usage (should be the same as shallow()):
+ *
+ * const wrapper = shallowWithIntl(<Component />);
+ */
+export const shallowWithIntl = children => {
+  return shallow(<I18nProvider>{children}</I18nProvider>, {
+    context: { intl },
+    childContextTypes: { intl },
+  })
+    .childAt(0)
+    .dive()
+    .shallow();
+};

--- a/x-pack/plugins/enterprise_search/public/applications/app_search/components/empty_states/empty_state.tsx
+++ b/x-pack/plugins/enterprise_search/public/applications/app_search/components/empty_states/empty_state.tsx
@@ -6,6 +6,7 @@
 
 import React, { useContext } from 'react';
 import { EuiPage, EuiPageBody, EuiPageContent, EuiEmptyPrompt, EuiButton } from '@elastic/eui';
+import { FormattedMessage } from '@kbn/i18n/react';
 
 import { sendTelemetry } from '../../../shared/telemetry';
 import { SetAppSearchBreadcrumbs as SetBreadcrumbs } from '../../../shared/kibana_breadcrumbs';
@@ -39,17 +40,34 @@ export const EmptyState: React.FC<> = () => {
         <EuiPageContent>
           <EuiEmptyPrompt
             iconType="eyeClosed"
-            title={<h2>There’s nothing here yet</h2>}
+            title={
+              <h2>
+                <FormattedMessage
+                  id="xpack.appSearch.emptyState.title"
+                  defaultMessage="There’s nothing here yet"
+                />
+              </h2>
+            }
             titleSize="l"
             body={
               <p>
-                Looks like you don’t have any App Search engines.
-                <br /> Let’s create your first one now.
+                <FormattedMessage
+                  id="xpack.appSearch.emptyState.description1"
+                  defaultMessage="Looks like you don’t have any App Search engines."
+                />
+                <br />
+                <FormattedMessage
+                  id="xpack.appSearch.emptyState.description2"
+                  defaultMessage="Let’s create your first one now."
+                />
               </p>
             }
             actions={
               <EuiButton iconType="popout" fill {...buttonProps}>
-                Create your first Engine
+                <FormattedMessage
+                  id="xpack.appSearch.emptyState.createFirstEngineCta"
+                  defaultMessage="Create your first Engine"
+                />
               </EuiButton>
             }
           />

--- a/x-pack/plugins/enterprise_search/public/applications/app_search/components/empty_states/empty_states.test.tsx
+++ b/x-pack/plugins/enterprise_search/public/applications/app_search/components/empty_states/empty_states.test.tsx
@@ -9,6 +9,8 @@ import '../../../__mocks__/shallow_usecontext.mock';
 import React from 'react';
 import { shallow } from 'enzyme';
 import { EuiEmptyPrompt, EuiButton, EuiCode, EuiLoadingContent } from '@elastic/eui';
+import { FormattedMessage } from '@kbn/i18n/react';
+import { shallowWithIntl } from '../../../__mocks__';
 
 jest.mock('../../utils/get_username', () => ({ getUserName: jest.fn() }));
 import { getUserName } from '../../utils/get_username';
@@ -24,38 +26,36 @@ import { ErrorState, NoUserState, EmptyState, LoadingState } from './';
 describe('ErrorState', () => {
   it('renders', () => {
     const wrapper = shallow(<ErrorState />);
-    const prompt = wrapper.find(EuiEmptyPrompt);
 
-    expect(prompt).toHaveLength(1);
-    expect(prompt.prop('title')).toEqual(<h2>Cannot connect to App Search</h2>);
+    expect(wrapper.find(EuiEmptyPrompt)).toHaveLength(1);
   });
 });
 
 describe('NoUserState', () => {
   it('renders', () => {
     const wrapper = shallow(<NoUserState />);
-    const prompt = wrapper.find(EuiEmptyPrompt);
 
-    expect(prompt).toHaveLength(1);
-    expect(prompt.prop('title')).toEqual(<h2>Cannot find App Search account</h2>);
+    expect(wrapper.find(EuiEmptyPrompt)).toHaveLength(1);
   });
 
   it('renders with username', () => {
     getUserName.mockImplementationOnce(() => 'dolores-abernathy');
-    const wrapper = shallow(<NoUserState />);
+    const wrapper = shallowWithIntl(<NoUserState />);
     const prompt = wrapper.find(EuiEmptyPrompt).dive();
+    const description1 = prompt
+      .find(FormattedMessage)
+      .at(1)
+      .dive();
 
-    expect(prompt.find(EuiCode).prop('children')).toContain('dolores-abernathy');
+    expect(description1.find(EuiCode).prop('children')).toContain('dolores-abernathy');
   });
 });
 
 describe('EmptyState', () => {
   it('renders', () => {
     const wrapper = shallow(<EmptyState />);
-    const prompt = wrapper.find(EuiEmptyPrompt);
 
-    expect(prompt).toHaveLength(1);
-    expect(prompt.prop('title')).toEqual(<h2>There’s nothing here yet</h2>);
+    expect(wrapper.find(EuiEmptyPrompt)).toHaveLength(1);
   });
 
   it('sends telemetry on create first engine click', () => {

--- a/x-pack/plugins/enterprise_search/public/applications/app_search/components/empty_states/error_state.tsx
+++ b/x-pack/plugins/enterprise_search/public/applications/app_search/components/empty_states/error_state.tsx
@@ -6,6 +6,7 @@
 
 import React, { useContext } from 'react';
 import { EuiPage, EuiPageBody, EuiPageContent, EuiEmptyPrompt, EuiCode } from '@elastic/eui';
+import { FormattedMessage } from '@kbn/i18n/react';
 
 import { EuiButton } from '../../../shared/react_router_helpers';
 import { SetAppSearchBreadcrumbs as SetBreadcrumbs } from '../../../shared/kibana_breadcrumbs';
@@ -29,23 +30,43 @@ export const ErrorState: ReactFC<> = () => {
           <EuiEmptyPrompt
             iconType="alert"
             iconColor="danger"
-            title={<h2>Cannot connect to App Search</h2>}
+            title={
+              <h2>
+                <FormattedMessage
+                  id="xpack.appSearch.errorConnectingState.title"
+                  defaultMessage="Cannot connect to App Search"
+                />
+              </h2>
+            }
             titleSize="l"
             body={
               <>
                 <p>
-                  We cannot connect to the App Search instance at the configured host URL:{' '}
-                  <EuiCode>{enterpriseSearchUrl}</EuiCode>
+                  <FormattedMessage
+                    id="xpack.appSearch.errorConnectingState.description1"
+                    defaultMessage="We cannot connect to the App Search instance at the configured host URL: {enterpriseSearchUrl}"
+                    values={{
+                      enterpriseSearchUrl: <EuiCode>{enterpriseSearchUrl}</EuiCode>,
+                    }}
+                  />
                 </p>
                 <p>
-                  Please ensure your App Search host URL is configured correctly within{' '}
-                  <EuiCode>config/kibana.yml</EuiCode>.
+                  <FormattedMessage
+                    id="xpack.appSearch.errorConnectingState.description2"
+                    defaultMessage="Please ensure your App Search host URL is configured correctly within {configFile}."
+                    values={{
+                      configFile: <EuiCode>config/kibana.yml</EuiCode>,
+                    }}
+                  />
                 </p>
               </>
             }
             actions={
               <EuiButton iconType="help" fill to="/setup_guide">
-                Review the setup guide
+                <FormattedMessage
+                  id="xpack.appSearch.errorConnectingState.setupGuideCta"
+                  defaultMessage="Review the setup guide"
+                />
               </EuiButton>
             }
           />

--- a/x-pack/plugins/enterprise_search/public/applications/app_search/components/empty_states/no_user_state.tsx
+++ b/x-pack/plugins/enterprise_search/public/applications/app_search/components/empty_states/no_user_state.tsx
@@ -6,6 +6,7 @@
 
 import React from 'react';
 import { EuiPage, EuiPageBody, EuiPageContent, EuiEmptyPrompt, EuiCode } from '@elastic/eui';
+import { FormattedMessage } from '@kbn/i18n/react';
 
 import { SetAppSearchBreadcrumbs as SetBreadcrumbs } from '../../../shared/kibana_breadcrumbs';
 import { SendAppSearchTelemetry as SendTelemetry } from '../../../shared/telemetry';
@@ -27,21 +28,31 @@ export const NoUserState: React.FC<> = () => {
         <EuiPageContent>
           <EuiEmptyPrompt
             iconType="lock"
-            title={<h2>Cannot find App Search account</h2>}
+            title={
+              <h2>
+                <FormattedMessage
+                  id="xpack.appSearch.noUserState.title"
+                  defaultMessage="Cannot find App Search account"
+                />
+              </h2>
+            }
             titleSize="l"
             body={
               <>
                 <p>
-                  We cannot find an App Search account matching your username
-                  {username && (
-                    <>
-                      : <EuiCode>{username}</EuiCode>
-                    </>
-                  )}
-                  .
+                  <FormattedMessage
+                    id="xpack.appSearch.noUserState.description1"
+                    defaultMessage="We cannot find an App Search account matching your username{username}."
+                    values={{
+                      username: username ? <EuiCode>{username}</EuiCode> : '',
+                    }}
+                  />
                 </p>
                 <p>
-                  Please contact your App Search administrator to request an invite for that user.
+                  <FormattedMessage
+                    id="xpack.appSearch.noUserState.description2"
+                    defaultMessage="Please contact your App Search administrator to request an invite for that user."
+                  />
                 </p>
               </>
             }

--- a/x-pack/plugins/enterprise_search/public/applications/app_search/components/engine_overview/engine_overview.test.tsx
+++ b/x-pack/plugins/enterprise_search/public/applications/app_search/components/engine_overview/engine_overview.test.tsx
@@ -10,9 +10,10 @@ import React from 'react';
 import { act } from 'react-dom/test-utils';
 import { render } from 'enzyme';
 
+import { I18nProvider } from '@kbn/i18n/react';
 import { KibanaContext } from '../../../';
 import { LicenseContext } from '../../../shared/licensing';
-import { mountWithKibanaContext, mockKibanaContext } from '../../../__mocks__';
+import { mountWithContext, mockKibanaContext } from '../../../__mocks__';
 
 import { EmptyState, ErrorState, NoUserState } from '../empty_states';
 import { EngineTable } from './engine_table';
@@ -23,12 +24,15 @@ describe('EngineOverview', () => {
   describe('non-happy-path states', () => {
     it('isLoading', () => {
       // We use render() instead of mount() here to not trigger lifecycle methods (i.e., useEffect)
+      // TODO: Consider pulling this out to a renderWithContext mock/helper
       const wrapper = render(
-        <KibanaContext.Provider value={{ http: {} }}>
-          <LicenseContext.Provider value={{ license: {} }}>
-            <EngineOverview />
-          </LicenseContext.Provider>
-        </KibanaContext.Provider>
+        <I18nProvider>
+          <KibanaContext.Provider value={{ http: {} }}>
+            <LicenseContext.Provider value={{ license: {} }}>
+              <EngineOverview />
+            </LicenseContext.Provider>
+          </KibanaContext.Provider>
+        </I18nProvider>
       );
 
       // render() directly renders HTML which means we have to look for selectors instead of for LoadingState directly
@@ -164,12 +168,7 @@ describe('EngineOverview', () => {
     // TBH, I don't fully understand why since Enzyme's mount is supposed to
     // have act() baked in - could be because of the wrapping context provider?
     await act(async () => {
-      wrapper = mountWithKibanaContext(
-        <LicenseContext.Provider value={{ license }}>
-          <EngineOverview />
-        </LicenseContext.Provider>,
-        { http: httpMock }
-      );
+      wrapper = mountWithContext(<EngineOverview />, { http: httpMock, license });
     });
     wrapper.update(); // This seems to be required for the DOM to actually update
 

--- a/x-pack/plugins/enterprise_search/public/applications/app_search/components/engine_overview/engine_overview.test.tsx
+++ b/x-pack/plugins/enterprise_search/public/applications/app_search/components/engine_overview/engine_overview.test.tsx
@@ -70,7 +70,7 @@ describe('EngineOverview', () => {
       results: [
         {
           name: 'hello-world',
-          created_at: 'somedate',
+          created_at: 'Fri, 1 Jan 1970 12:00:00 +0000',
           document_count: 50,
           field_count: 10,
         },

--- a/x-pack/plugins/enterprise_search/public/applications/app_search/components/engine_overview/engine_overview.tsx
+++ b/x-pack/plugins/enterprise_search/public/applications/app_search/components/engine_overview/engine_overview.tsx
@@ -14,6 +14,7 @@ import {
   EuiTitle,
   EuiSpacer,
 } from '@elastic/eui';
+import { FormattedMessage } from '@kbn/i18n/react';
 
 import { SetAppSearchBreadcrumbs as SetBreadcrumbs } from '../../../shared/kibana_breadcrumbs';
 import { SendAppSearchTelemetry as SendTelemetry } from '../../../shared/telemetry';
@@ -100,7 +101,10 @@ export const EngineOverview: ReactFC<> = () => {
             <EuiTitle size="s">
               <h2>
                 <img src={EnginesIcon} alt="" className="engine-icon" />
-                Engines
+                <FormattedMessage
+                  id="xpack.appSearch.enginesOverview.engines"
+                  defaultMessage="Engines"
+                />
               </h2>
             </EuiTitle>
           </EuiPageContentHeader>
@@ -122,7 +126,10 @@ export const EngineOverview: ReactFC<> = () => {
                 <EuiTitle size="s">
                   <h2>
                     <img src={MetaEnginesIcon} alt="" className="engine-icon" />
-                    Meta Engines
+                    <FormattedMessage
+                      id="xpack.appSearch.enginesOverview.metaEngines"
+                      defaultMessage="Meta Engines"
+                    />
                   </h2>
                 </EuiTitle>
               </EuiPageContentHeader>

--- a/x-pack/plugins/enterprise_search/public/applications/app_search/components/engine_overview/engine_table.test.tsx
+++ b/x-pack/plugins/enterprise_search/public/applications/app_search/components/engine_overview/engine_table.test.tsx
@@ -7,7 +7,7 @@
 import React from 'react';
 import { EuiBasicTable, EuiPagination, EuiButtonEmpty, EuiLink } from '@elastic/eui';
 
-import { mountWithKibanaContext } from '../../../__mocks__';
+import { mountWithContext } from '../../../__mocks__';
 jest.mock('../../../shared/telemetry', () => ({ sendTelemetry: jest.fn() }));
 import { sendTelemetry } from '../../../shared/telemetry';
 
@@ -16,7 +16,7 @@ import { EngineTable } from './engine_table';
 describe('EngineTable', () => {
   const onPaginate = jest.fn(); // onPaginate updates the engines API call upstream
 
-  const wrapper = mountWithKibanaContext(
+  const wrapper = mountWithContext(
     <EngineTable
       data={[
         {
@@ -71,7 +71,7 @@ describe('EngineTable', () => {
   });
 
   it('handles empty data', () => {
-    const emptyWrapper = mountWithKibanaContext(
+    const emptyWrapper = mountWithContext(
       <EngineTable data={[]} pagination={{ totalEngines: 0 }} />
     );
     const emptyTable = wrapper.find(EuiBasicTable);

--- a/x-pack/plugins/enterprise_search/public/applications/app_search/components/engine_overview/engine_table.tsx
+++ b/x-pack/plugins/enterprise_search/public/applications/app_search/components/engine_overview/engine_table.tsx
@@ -6,7 +6,7 @@
 
 import React, { useContext } from 'react';
 import { EuiBasicTable, EuiLink } from '@elastic/eui';
-import { FormattedMessage } from '@kbn/i18n/react';
+import { FormattedMessage, FormattedDate, FormattedNumber } from '@kbn/i18n/react';
 import { i18n } from '@kbn/i18n';
 
 import { sendTelemetry } from '../../../shared/telemetry';
@@ -72,14 +72,10 @@ export const EngineTable: ReactFC<IEngineTableProps> = ({
         defaultMessage: 'Created At',
       }),
       dataType: 'string',
-      render: dateString => {
+      render: dateString => (
         // e.g., January 1, 1970
-        return new Date(dateString).toLocaleDateString('en-US', {
-          year: 'numeric',
-          month: 'long',
-          day: 'numeric',
-        });
-      },
+        <FormattedDate value={new Date(dateString)} year="numeric" month="long" day="numeric" />
+      ),
     },
     {
       field: 'document_count',
@@ -87,7 +83,7 @@ export const EngineTable: ReactFC<IEngineTableProps> = ({
         defaultMessage: 'Document Count',
       }),
       dataType: 'number',
-      render: number => number.toLocaleString(), // Display with comma thousand separators
+      render: number => <FormattedNumber value={number} />,
       truncateText: true,
     },
     {
@@ -96,7 +92,7 @@ export const EngineTable: ReactFC<IEngineTableProps> = ({
         defaultMessage: 'Field Count',
       }),
       dataType: 'number',
-      render: number => number.toLocaleString(), // Display with comma thousand separators
+      render: number => <FormattedNumber value={number} />,
       truncateText: true,
     },
     {

--- a/x-pack/plugins/enterprise_search/public/applications/app_search/components/engine_overview/engine_table.tsx
+++ b/x-pack/plugins/enterprise_search/public/applications/app_search/components/engine_overview/engine_table.tsx
@@ -6,6 +6,8 @@
 
 import React, { useContext } from 'react';
 import { EuiBasicTable, EuiLink } from '@elastic/eui';
+import { FormattedMessage } from '@kbn/i18n/react';
+import { i18n } from '@kbn/i18n';
 
 import { sendTelemetry } from '../../../shared/telemetry';
 import { KibanaContext, IKibanaContext } from '../../../index';
@@ -51,7 +53,9 @@ export const EngineTable: ReactFC<IEngineTableProps> = ({
   const columns = [
     {
       field: 'name',
-      name: 'Name',
+      name: i18n.translate('xpack.appSearch.enginesOverview.table.column.name', {
+        defaultMessage: 'Name',
+      }),
       render: name => <EuiLink {...engineLinkProps(name)}>{name}</EuiLink>,
       width: '30%',
       truncateText: true,
@@ -64,7 +68,9 @@ export const EngineTable: ReactFC<IEngineTableProps> = ({
     },
     {
       field: 'created_at',
-      name: 'Created At',
+      name: i18n.translate('xpack.appSearch.enginesOverview.table.column.createdAt', {
+        defaultMessage: 'Created At',
+      }),
       dataType: 'string',
       render: dateString => {
         // e.g., January 1, 1970
@@ -77,23 +83,36 @@ export const EngineTable: ReactFC<IEngineTableProps> = ({
     },
     {
       field: 'document_count',
-      name: 'Document Count',
+      name: i18n.translate('xpack.appSearch.enginesOverview.table.column.documentCount', {
+        defaultMessage: 'Document Count',
+      }),
       dataType: 'number',
       render: number => number.toLocaleString(), // Display with comma thousand separators
       truncateText: true,
     },
     {
       field: 'field_count',
-      name: 'Field Count',
+      name: i18n.translate('xpack.appSearch.enginesOverview.table.column.fieldCount', {
+        defaultMessage: 'Field Count',
+      }),
       dataType: 'number',
       render: number => number.toLocaleString(), // Display with comma thousand separators
       truncateText: true,
     },
     {
       field: 'name',
-      name: 'Actions',
+      name: i18n.translate('xpack.appSearch.enginesOverview.table.column.actions', {
+        defaultMessage: 'Actions',
+      }),
       dataType: 'string',
-      render: name => <EuiLink {...engineLinkProps(name)}>Manage</EuiLink>,
+      render: name => (
+        <EuiLink {...engineLinkProps(name)}>
+          <FormattedMessage
+            id="xpack.appSearch.enginesOverview.table.action.manage"
+            defaultMessage="Manage"
+          />
+        </EuiLink>
+      ),
       align: 'right',
       width: '100px',
     },

--- a/x-pack/plugins/enterprise_search/public/applications/app_search/components/engine_overview_header/engine_overview_header.tsx
+++ b/x-pack/plugins/enterprise_search/public/applications/app_search/components/engine_overview_header/engine_overview_header.tsx
@@ -6,6 +6,7 @@
 
 import React, { useContext } from 'react';
 import { EuiPageHeader, EuiPageHeaderSection, EuiTitle, EuiButton } from '@elastic/eui';
+import { FormattedMessage } from '@kbn/i18n/react';
 
 import { sendTelemetry } from '../../../shared/telemetry';
 import { KibanaContext, IKibanaContext } from '../../../index';
@@ -36,11 +37,18 @@ export const EngineOverviewHeader: React.FC<> = () => {
     <EuiPageHeader>
       <EuiPageHeaderSection>
         <EuiTitle size="l">
-          <h1>Engine Overview</h1>
+          <h1>
+            <FormattedMessage
+              id="xpack.appSearch.enginesOverview.title"
+              defaultMessage="Engine Overview"
+            />
+          </h1>
         </EuiTitle>
       </EuiPageHeaderSection>
       <EuiPageHeaderSection>
-        <EuiButton {...buttonProps}>Launch App Search</EuiButton>
+        <EuiButton {...buttonProps}>
+          <FormattedMessage id="xpack.appSearch.productCta" defaultMessage="Launch App Search" />
+        </EuiButton>
       </EuiPageHeaderSection>
     </EuiPageHeader>
   );

--- a/x-pack/plugins/enterprise_search/public/applications/app_search/components/setup_guide/setup_guide.tsx
+++ b/x-pack/plugins/enterprise_search/public/applications/app_search/components/setup_guide/setup_guide.tsx
@@ -23,6 +23,8 @@ import {
   EuiAccordion,
   EuiLink,
 } from '@elastic/eui';
+import { FormattedMessage } from '@kbn/i18n/react';
+import { i18n } from '@kbn/i18n';
 
 import { SetAppSearchBreadcrumbs as SetBreadcrumbs } from '../../../shared/kibana_breadcrumbs';
 import { SendAppSearchTelemetry as SendTelemetry } from '../../../shared/telemetry';
@@ -38,7 +40,9 @@ export const SetupGuide: React.FC<> = () => {
 
       <EuiPageSideBar>
         <EuiText color="subdued" size="s">
-          <strong>Setup Guide</strong>
+          <strong>
+            <FormattedMessage id="xpack.appSearch.setupGuide.title" defaultMessage="Setup Guide" />
+          </strong>
         </EuiText>
         <EuiSpacer size="s" />
 
@@ -48,7 +52,9 @@ export const SetupGuide: React.FC<> = () => {
           </EuiFlexItem>
           <EuiFlexItem>
             <EuiTitle size="m">
-              <h1>App Search</h1>
+              <h1>
+                <FormattedMessage id="xpack.appSearch.productTitle" defaultMessage="App Search" />
+              </h1>
             </EuiTitle>
           </EuiFlexItem>
         </EuiFlexGroup>
@@ -61,7 +67,10 @@ export const SetupGuide: React.FC<> = () => {
           <img
             className="setup-guide__thumbnail"
             src={GettingStarted}
-            alt="Getting started with App Search - in this short video we'll guide you through how to get App Search up and running"
+            alt={i18n.translate('xpack.appSearch.setupGuide.videoAlt', {
+              defaultMessage:
+                "Getting started with App Search - in this short video we'll guide you through how to get App Search up and running",
+            })}
             width="1280"
             height-="720"
           />
@@ -69,15 +78,19 @@ export const SetupGuide: React.FC<> = () => {
 
         <EuiTitle size="s">
           <p>
-            Elastic App Search provides user-friendly tools to design and deploy a powerful search
-            to your websites or web/mobile applications.
+            <FormattedMessage
+              id="xpack.appSearch.setupGuide.description"
+              defaultMessage="Elastic App Search provides user-friendly tools to design and deploy a powerful search to your websites or web/mobile applications."
+            />
           </p>
         </EuiTitle>
         <EuiSpacer size="m" />
         <EuiText>
           <p>
-            App Search has not been configured in your Kibana instance yet. To get started, follow
-            the instructions on this page.
+            <FormattedMessage
+              id="xpack.appSearch.setupGuide.notConfigured"
+              defaultMessage="App Search has not been configured in your Kibana instance yet. To get started, follow the instructions on this page."
+            />
           </p>
         </EuiText>
       </EuiPageSideBar>
@@ -88,13 +101,20 @@ export const SetupGuide: React.FC<> = () => {
             headingElement="h2"
             steps={[
               {
-                title: 'Add your App Search host URL to your Kibana configuration',
+                title: i18n.translate('xpack.appSearch.setupGuide.step1.title', {
+                  defaultMessage: 'Add your App Search host URL to your Kibana configuration',
+                }),
                 children: (
                   <EuiText>
                     <p>
-                      Within your <EuiCode>config/kibana.yml</EuiCode> file, set{' '}
-                      <EuiCode>enterpriseSearch.host</EuiCode> to the URL of your App Search
-                      instance. For example:
+                      <FormattedMessage
+                        id="xpack.appSearch.setupGuide.step1.instruction1"
+                        defaultMessage="Within your {configFile} file, set {configSetting} to the URL of your App Search instance. For example:"
+                        values={{
+                          configFile: <EuiCode>config/kibana.yml</EuiCode>,
+                          configSetting: <EuiCode>enterpriseSearch.host</EuiCode>,
+                        }}
+                      />
                     </p>
                     <EuiCodeBlock language="yml">
                       enterpriseSearch.host: &apos;http://localhost:3002&apos;
@@ -103,75 +123,110 @@ export const SetupGuide: React.FC<> = () => {
                 ),
               },
               {
-                title: 'Reload your Kibana instance',
+                title: i18n.translate('xpack.appSearch.setupGuide.step2.title', {
+                  defaultMessage: 'Reload your Kibana instance',
+                }),
                 children: (
                   <EuiText>
                     <p>
-                      Restart Kibana to pick up the configuration changes from the previous step.
+                      <FormattedMessage
+                        id="xpack.appSearch.setupGuide.step2.instruction1"
+                        defaultMessage="Restart Kibana to pick up the configuration changes from the previous step."
+                      />
                     </p>
                     <p>
-                      If you’re using{' '}
-                      <EuiLink
-                        href="https://swiftype.com/documentation/app-search/self-managed/security#elasticsearch-native-realm"
-                        target="_blank"
-                      >
-                        Elasticsearch Native
-                      </EuiLink>{' '}
-                      auth within App Search - you’re all set! All users should be able to use App
-                      Search in Kibana automatically, inheriting the existing access and permissions
-                      they have within App Search.
+                      <FormattedMessage
+                        id="xpack.appSearch.setupGuide.step2.instruction2"
+                        defaultMessage="If you’re using {elasticsearchNativeAuthLink} within App Search - you’re all set! All users should be able to use App Search in Kibana automatically, inheriting the existing access and permissions they have within App Search."
+                        values={{
+                          elasticsearchNativeAuthLink: (
+                            <EuiLink
+                              href="https://swiftype.com/documentation/app-search/self-managed/security#elasticsearch-native-realm"
+                              target="_blank"
+                            >
+                              Elasticsearch Native Auth
+                            </EuiLink>
+                          ),
+                        }}
+                      />
                     </p>
                   </EuiText>
                 ),
               },
               {
-                title: 'Troubleshooting issues',
+                title: i18n.translate('xpack.appSearch.setupGuide.step3.title', {
+                  defaultMessage: 'Troubleshooting issues',
+                }),
                 children: (
                   <>
                     <EuiAccordion
-                      buttonContent="App Search and Kibana are on different Elasticsearch clusters"
-                      id="standard-auth"
+                      buttonContent={i18n.translate(
+                        'xpack.appSearch.troubleshooting.differentEsClusters.title',
+                        {
+                          defaultMessage:
+                            'App Search and Kibana are on different Elasticsearch clusters',
+                        }
+                      )}
+                      id="differentEsClusters"
                       paddingSize="s"
                     >
                       <EuiText>
                         <p>
-                          This plugin does not currently support App Search and Kibana running on
-                          different clusters.
+                          <FormattedMessage
+                            id="xpack.appSearch.troubleshooting.differentEsClusters.description"
+                            defaultMessage="This plugin does not currently support App Search and Kibana running on different clusters."
+                          />
                         </p>
                       </EuiText>
                     </EuiAccordion>
                     <EuiSpacer />
                     <EuiAccordion
-                      buttonContent="App Search and Kibana are on different authentication methods"
-                      id="standard-auth"
+                      buttonContent={i18n.translate(
+                        'xpack.appSearch.troubleshooting.differentAuth.title',
+                        {
+                          defaultMessage:
+                            'App Search and Kibana are on different authentication methods',
+                        }
+                      )}
+                      id="differentAuth"
                       paddingSize="s"
                     >
                       <EuiText>
                         <p>
-                          This plugin does not currently support App Search and Kibana operating on
-                          different authentication methods (for example, App Search using a
-                          different SAML provider than Kibana).
+                          <FormattedMessage
+                            id="xpack.appSearch.troubleshooting.differentAuth.description"
+                            defaultMessage="This plugin does not currently support App Search and Kibana operating on different authentication methods (for example, App Search using a different SAML provider than Kibana)."
+                          />
                         </p>
                       </EuiText>
                     </EuiAccordion>
                     <EuiSpacer />
                     <EuiAccordion
-                      buttonContent="App Search on Standard authentication"
-                      id="standard-auth"
+                      buttonContent={i18n.translate(
+                        'xpack.appSearch.troubleshooting.standardAuth.title',
+                        {
+                          defaultMessage: 'App Search on Standard authentication',
+                        }
+                      )}
+                      id="standardAuth"
                       paddingSize="s"
                     >
                       <EuiText>
                         <p>
-                          App Search operating on{' '}
-                          <EuiLink
-                            href="https://swiftype.com/documentation/app-search/self-managed/security#standard"
-                            target="_blank"
-                          >
-                            Standard Auth
-                          </EuiLink>{' '}
-                          is currently not fully supported by this plugin. Users created in App
-                          Search must be granted Kibana access. Users created in Kibana will see
-                          &quot;Cannot find App Search account&quot; error messages.
+                          <FormattedMessage
+                            id="xpack.appSearch.troubleshooting.standardAuth.description"
+                            defaultMessage='App Search operating on {standardAuthLink} is currently not fully supported by this plugin. Users created in App Search must be granted Kibana access. Users created in Kibana will see "Cannot find App Search account" error messages.'
+                            values={{
+                              standardAuthLink: (
+                                <EuiLink
+                                  href="https://swiftype.com/documentation/app-search/self-managed/security#standard"
+                                  target="_blank"
+                                >
+                                  Standard Auth
+                                </EuiLink>
+                              ),
+                            }}
+                          />
                         </p>
                       </EuiText>
                     </EuiAccordion>

--- a/x-pack/plugins/enterprise_search/public/applications/index.tsx
+++ b/x-pack/plugins/enterprise_search/public/applications/index.tsx
@@ -8,6 +8,7 @@ import React from 'react';
 import ReactDOM from 'react-dom';
 import { Router, Route, Redirect } from 'react-router-dom';
 
+import { I18nProvider } from '@kbn/i18n/react';
 import { CoreStart, AppMountParams, HttpHandler } from 'src/core/public';
 import { ClientConfigType, PluginsSetup } from '../plugin';
 import { TSetBreadcrumbs } from './shared/kibana_breadcrumbs';
@@ -37,20 +38,22 @@ export const renderApp = (
   plugins: PluginsSetup
 ) => {
   ReactDOM.render(
-    <KibanaContext.Provider
-      value={{
-        http: core.http,
-        enterpriseSearchUrl: config.host,
-        setBreadcrumbs: core.chrome.setBreadcrumbs,
-        license$: plugins.licensing.license$,
-      }}
-    >
-      <LicenseProvider>
-        <Router history={params.history}>
-          <App />
-        </Router>
-      </LicenseProvider>
-    </KibanaContext.Provider>,
+    <I18nProvider>
+      <KibanaContext.Provider
+        value={{
+          http: core.http,
+          enterpriseSearchUrl: config.host,
+          setBreadcrumbs: core.chrome.setBreadcrumbs,
+          license$: plugins.licensing.license$,
+        }}
+      >
+        <LicenseProvider>
+          <Router history={params.history}>
+            <App />
+          </Router>
+        </LicenseProvider>
+      </KibanaContext.Provider>
+    </I18nProvider>,
     params.element
   );
   return () => ReactDOM.unmountComponentAtNode(params.element);

--- a/x-pack/plugins/enterprise_search/public/applications/shared/licensing/license_context.test.tsx
+++ b/x-pack/plugins/enterprise_search/public/applications/shared/licensing/license_context.test.tsx
@@ -6,7 +6,7 @@
 
 import React, { useContext } from 'react';
 
-import { mountWithKibanaContext } from '../../__mocks__';
+import { mountWithContext } from '../../__mocks__';
 import { LicenseContext, ILicenseContext } from './';
 
 describe('LicenseProvider', () => {
@@ -16,11 +16,7 @@ describe('LicenseProvider', () => {
   };
 
   it('renders children', () => {
-    const wrapper = mountWithKibanaContext(
-      <LicenseContext.Provider value={{ license: { type: 'basic' } }}>
-        <MockComponent />
-      </LicenseContext.Provider>
-    );
+    const wrapper = mountWithContext(<MockComponent />, { license: { type: 'basic' } });
 
     expect(wrapper.find('.license-test')).toHaveLength(1);
     expect(wrapper.text()).toEqual('basic');


### PR DESCRIPTION
## Summary

Per [Kibana's PR checklist](https://github.com/elastic/kibana/blob/master/packages/kbn-i18n/README.md#react), we should be parsing all static strings/copy through either `<FormattedMessage>` or `i18n.translate()`.

As always, testing mocks are kind of a pain to follow, so I recommend checking out [just the first commit](https://github.com/constancecchen/kibana/commit/5bce32e188274c499be16c8bb984457b032b5f12) which has just the formatting changes, and then the [second commit](https://github.com/constancecchen/kibana/commit/2514ae5d00919e4f19253a9eac05bd61552a7d03) which has some testing refactors (such as an easier-to-use `mountWithContext` helper that contains all parent contexts)

### Resources:

- https://github.com/elastic/kibana/blob/master/packages/kbn-i18n/README.md
- https://github.com/elastic/kibana/blob/master/packages/kbn-i18n/GUIDELINE.md
- https://github.com/elastic/kibana/blob/master/src/dev/i18n/README.md