### PR TITLE
Add README and CODEOWNERS + disable plugin on 8.x

### DIFF
--- a/.github/CODEOWNERS
+++ b/.github/CODEOWNERS
@@ -190,6 +190,10 @@
 # Design
 **/*.scss  @elastic/kibana-design
 
+# Enterprise Search
+/x-pack/plugins/enterprise_search/ @elastic/app-search-frontend @elastic/workplace-search-frontend
+/x-pack/test/functional_enterprise_search/ @elastic/app-search-frontend @elastic/workplace-search-frontend
+
 # Elasticsearch UI
 /src/plugins/dev_tools/ @elastic/es-ui
 /src/plugins/console/  @elastic/es-ui

--- a/x-pack/plugins/enterprise_search/README.md
+++ b/x-pack/plugins/enterprise_search/README.md
@@ -1,0 +1,25 @@
+# Enterprise Search
+
+## Overview
+
+This plugin's goal is to provide a Kibana user interface to the Enterprise Search solution's products (App Search and Workplace Search). In its current MVP state, the plugin provides a basic engines overview from App Search with the goal of gathering user feedback and raising product awareness.
+
+## Development
+
+1. When developing locally, Enterprise Search should be running locally alongside Kibana on `localhost:3002`.
+2. Update `config/kibana.dev.yml` with `enterpriseSearch.host: 'http://localhost:3002'`
+3. For faster QA/development, run Enterprise Search on `elasticsearch-native` auth and log in as the `elastic` superuser on Kibana.
+
+## Testing
+
+### Unit tests
+
+From `kibana-root-folder/x-pack`, run:
+
+```bash
+yarn test:jest plugins/enterprise_search
+```
+
+### E2E tests
+
+See [our functional test runner README](../../test/functional_enterprise_search).

--- a/x-pack/plugins/enterprise_search/server/index.ts
+++ b/x-pack/plugins/enterprise_search/server/index.ts
@@ -13,6 +13,7 @@ export const plugin = (initializerContext: PluginInitializerContext) => {
 };
 
 export const configSchema = schema.object({
+  enabled: schema.boolean({ defaultValue: false }), // TODO: This plugin is disabled for master/8.x only. This line should be removed once Enterprise Search becomes 8.x compatible
   host: schema.maybe(schema.string()),
 });
 


### PR DESCRIPTION
- Per plugin review feedback meeting, add plugin README and CODEOWNERS
- Temporarily disable plugin for 8.x, since Enterprise Search currently does not support elasticsearch 8.x