### PR TITLE
Fixed TS warnings in E2E tests

### DIFF
--- a/x-pack/test/functional_enterprise_search/apps/enterprise_search/with_host_configured/app_search/engines.ts
+++ b/x-pack/test/functional_enterprise_search/apps/enterprise_search/with_host_configured/app_search/engines.ts
@@ -7,8 +7,8 @@
 import expect from '@kbn/expect';
 import { EsArchiver } from 'src/es_archiver';
 import { AppSearchService, IEngine } from '../../../../services/app_search_service';
-import { Browser } from '../../../../../../../test/functional/services/browser';
-import { FtrProviderContext } from '../../../ftr_provider_context';
+import { Browser } from '../../../../../../../test/functional/services/common';
+import { FtrProviderContext } from '../../../../ftr_provider_context';
 
 export default function enterpriseSearchSetupEnginesTests({
   getService,

--- a/x-pack/test/functional_enterprise_search/apps/enterprise_search/with_host_configured/index.ts
+++ b/x-pack/test/functional_enterprise_search/apps/enterprise_search/with_host_configured/index.ts
@@ -4,7 +4,7 @@
  * you may not use this file except in compliance with the Elastic License.
  */
 
-import { FtrProviderContext } from '../../ftr_provider_context';
+import { FtrProviderContext } from '../../../ftr_provider_context';
 
 export default function ({ loadTestFile }: FtrProviderContext) {
   describe('Enterprise Search', function () {

--- a/x-pack/test/functional_enterprise_search/apps/enterprise_search/without_host_configured/app_search/setup_guide.ts
+++ b/x-pack/test/functional_enterprise_search/apps/enterprise_search/without_host_configured/app_search/setup_guide.ts
@@ -5,7 +5,7 @@
  */
 
 import expect from '@kbn/expect';
-import { FtrProviderContext } from '../../../ftr_provider_context';
+import { FtrProviderContext } from '../../../../ftr_provider_context';
 
 export default function enterpriseSearchSetupGuideTests({
   getService,

--- a/x-pack/test/functional_enterprise_search/apps/enterprise_search/without_host_configured/index.ts
+++ b/x-pack/test/functional_enterprise_search/apps/enterprise_search/without_host_configured/index.ts
@@ -4,7 +4,7 @@
  * you may not use this file except in compliance with the Elastic License.
  */
 
-import { FtrProviderContext } from '../../ftr_provider_context';
+import { FtrProviderContext } from '../../../ftr_provider_context';
 
 export default function ({ loadTestFile }: FtrProviderContext) {
   describe('Enterprise Search', function () {

--- a/x-pack/test/functional_enterprise_search/ftr_provider_context.d.ts
+++ b/x-pack/test/functional_enterprise_search/ftr_provider_context.d.ts
@@ -1,0 +1,12 @@
+/*
+ * Copyright Elasticsearch B.V. and/or licensed to Elasticsearch B.V. under one
+ * or more contributor license agreements. Licensed under the Elastic License;
+ * you may not use this file except in compliance with the Elastic License.
+ */
+
+import { GenericFtrProviderContext } from '@kbn/test/types/ftr';
+
+import { pageObjects } from './page_objects';
+import { services } from './services';
+
+export type FtrProviderContext = GenericFtrProviderContext<typeof services, typeof pageObjects>;

--- a/x-pack/test/functional_enterprise_search/page_objects/app_search.ts
+++ b/x-pack/test/functional_enterprise_search/page_objects/app_search.ts
@@ -5,23 +5,24 @@
  */
 
 import { FtrProviderContext } from '../ftr_provider_context';
-import { TestSubjects } from '../../../../../test/functional/services/test_subjects';
+import { TestSubjects } from '../../../../test/functional/services/common';
+import { WebElementWrapper } from '../../../../test/functional/services/lib/web_element_wrapper';
 
 export function AppSearchPageProvider({ getService, getPageObjects }: FtrProviderContext) {
   const PageObjects = getPageObjects(['common']);
   const testSubjects = getService('testSubjects') as TestSubjects;
 
   return {
-    async navigateToPage() {
+    async navigateToPage(): Promise<void> {
       return await PageObjects.common.navigateToApp('app_search');
     },
 
-    async getEngineLinks() {
+    async getEngineLinks(): Promise<WebElementWrapper[]> {
       const engines = await testSubjects.find('appSearchEngines');
       return await testSubjects.findAllDescendant('engineNameLink', engines);
     },
 
-    async getMetaEngineLinks() {
+    async getMetaEngineLinks(): Promise<WebElementWrapper[]> {
       const metaEngines = await testSubjects.find('appSearchMetaEngines');
       return await testSubjects.findAllDescendant('engineNameLink', metaEngines);
     },

--- a/x-pack/test/functional_enterprise_search/services/app_search_client.ts
+++ b/x-pack/test/functional_enterprise_search/services/app_search_client.ts
@@ -50,7 +50,7 @@ const makeRequest = <T>(method: string, path: string, body?: object): Promise<T>
             reject(e);
           }
 
-          if (res.statusCode > 299) {
+          if (res.statusCode && res.statusCode > 299) {
             reject('Error calling App Search API: ' + JSON.stringify(responseBody));
           }
 


### PR DESCRIPTION
This PR fixes lint errors from https://github.com/elastic/kibana/pull/66922/checks?check_run_id=740373586.