### PR TITLE
Workplace Search in Kibana MVP

### DIFF
--- a/x-pack/plugins/enterprise_search/server/plugin.ts
+++ b/x-pack/plugins/enterprise_search/server/plugin.ts
@@ -76,8 +76,8 @@ export class EnterpriseSearchPlugin implements Plugin {
       order: 0,
       icon: 'logoEnterpriseSearch',
       navLinkId: 'app_search', // TODO - remove this once functional tests no longer rely on navLinkId
-      app: ['kibana', 'app_search'], // TODO: 'enterprise_search', 'workplace_search'
-      catalogue: ['app_search'], // TODO: 'enterprise_search', 'workplace_search'
+      app: ['kibana', 'app_search', 'workplace_search'], // TODO: 'enterprise_search'
+      catalogue: ['app_search', 'workplace_search'], // TODO: 'enterprise_search'
       privileges: null,
     });
 

--- a/x-pack/test/ui_capabilities/common/nav_links_builder.ts
+++ b/x-pack/test/ui_capabilities/common/nav_links_builder.ts
@@ -19,6 +19,9 @@ export class NavLinksBuilder {
       app_search: {
         navLinkId: 'app_search',
       },
+      workplace_search: {
+        navLinkId: 'workplace_search',
+      },
     };
   }
 

--- a/x-pack/test/ui_capabilities/security_and_spaces/tests/catalogue.ts
+++ b/x-pack/test/ui_capabilities/security_and_spaces/tests/catalogue.ts
@@ -50,9 +50,10 @@ export default function catalogueTests({ getService }: FtrProviderContext) {
             expect(uiCapabilities.success).to.be(true);
             expect(uiCapabilities.value).to.have.property('catalogue');
             // everything except ml and monitoring and enterprise search is enabled
+            const exceptions = ['ml', 'monitoring', 'app_search', 'workplace_search'];
             const expected = mapValues(
               uiCapabilities.value!.catalogue,
-              (enabled, catalogueId) => !['ml', 'monitoring', 'app_search'].includes(catalogueId)
+              (enabled, catalogueId) => !exceptions.includes(catalogueId)
             );
             expect(uiCapabilities.value!.catalogue).to.eql(expected);
             break;

--- a/x-pack/test/ui_capabilities/security_and_spaces/tests/nav_links.ts
+++ b/x-pack/test/ui_capabilities/security_and_spaces/tests/nav_links.ts
@@ -51,7 +51,13 @@ export default function navLinksTests({ getService }: FtrProviderContext) {
             expect(uiCapabilities.success).to.be(true);
             expect(uiCapabilities.value).to.have.property('navLinks');
             expect(uiCapabilities.value!.navLinks).to.eql(
-              navLinksBuilder.except('ml', 'monitoring', 'enterprise_search', 'app_search')
+              navLinksBuilder.except(
+                'ml',
+                'monitoring',
+                'enterprise_search',
+                'app_search',
+                'workplace_search'
+              )
             );
             break;
           case 'superuser at nothing_space':

--- a/x-pack/test/ui_capabilities/security_only/tests/catalogue.ts
+++ b/x-pack/test/ui_capabilities/security_only/tests/catalogue.ts
@@ -48,9 +48,10 @@ export default function catalogueTests({ getService }: FtrProviderContext) {
             expect(uiCapabilities.success).to.be(true);
             expect(uiCapabilities.value).to.have.property('catalogue');
             // everything except ml and monitoring and enterprise_search is enabled
+            const exceptions = ['ml', 'monitoring', 'app_search', 'workplace_search'];
             const expected = mapValues(
               uiCapabilities.value!.catalogue,
-              (enabled, catalogueId) => !['ml', 'monitoring', 'app_search'].includes(catalogueId)
+              (enabled, catalogueId) => !exceptions.includes(catalogueId)
             );
             expect(uiCapabilities.value!.catalogue).to.eql(expected);
             break;

--- a/x-pack/test/ui_capabilities/security_only/tests/nav_links.ts
+++ b/x-pack/test/ui_capabilities/security_only/tests/nav_links.ts
@@ -49,7 +49,7 @@ export default function navLinksTests({ getService }: FtrProviderContext) {
             expect(uiCapabilities.success).to.be(true);
             expect(uiCapabilities.value).to.have.property('navLinks');
             expect(uiCapabilities.value!.navLinks).to.eql(
-              navLinksBuilder.except('ml', 'monitoring', 'app_search')
+              navLinksBuilder.except('ml', 'monitoring', 'app_search', 'workplace_search')
             );
             break;
           case 'foo_all':


### PR DESCRIPTION
## Summary

This PR adds Workplace Search to the Enterprise Search in Kibana MVP

![image](https://user-images.githubusercontent.com/1869731/86624293-b157cc00-bf88-11ea-8c58-f8b84b52e0b3.png)

### QA
**Standard auth**
_For this QA, it works best to log into Enterprise Search first as we have an issue where the #'s in the URLs aren't working when logged out in Rails. Not sure if this is worth the cycles to address before 7.9_
- [ ] Workplace Search admin page renders and matches `http://localhost:3002/ws#/org`
- [ ] Adding a source adds to recent activity at bottom, changes icon to checkmark in onboarding card and updates source count in Usage statistics (custom source is quickest)
- [ ] Adding a user changes icon to checkmark in onboarding card and updates user count in Usage statistics
- [ ] Once source has been added, user has been invited, and org name changed, the onboarding sections (sources, users, and org name) should be hidden.

**Native auth**
Same as Standard without the users cards

### Checklist

Delete any items that are not applicable to this PR.

- [x] Any text added follows [EUI's writing guidelines](https://elastic.github.io/eui/#/guidelines/writing), uses sentence case text and includes [i18n support](https://github.com/elastic/kibana/blob/master/packages/kbn-i18n/README.md)
- [x] [Documentation](https://github.com/elastic/kibana/blob/master/CONTRIBUTING.md#writing-documentation) was added for features that require explanation or tutorials
- [x] [Unit or functional tests](https://github.com/elastic/kibana/blob/master/CONTRIBUTING.md#cross-browser-compatibility) were updated or added to match the most common scenarios
- [x] This was checked for [keyboard-only and screenreader accessibility](https://developer.mozilla.org/en-US/docs/Learn/Tools_and_testing/Cross_browser_testing/Accessibility#Accessibility_testing_checklist)
- [x] This renders correctly on smaller devices using a responsive layout. (You can test this [in your browser](https://www.browserstack.com/guide/responsive-testing-on-local-server)
- [x] This was checked for [cross-browser compatibility](https://www.elastic.co/support/matrix#matrix_browsers)

### For maintainers

- [x] This was checked for breaking API changes and was [labeled appropriately](https://github.com/elastic/kibana/blob/master/CONTRIBUTING.md#release-notes-process)
