### PR TITLE
Public URL support for Elastic Cloud

### DIFF
--- a/x-pack/plugins/enterprise_search/public/applications/shared/enterprise_search_url/get_enterprise_search_url.test.ts
+++ b/x-pack/plugins/enterprise_search/public/applications/shared/enterprise_search_url/get_enterprise_search_url.test.ts
@@ -1,0 +1,30 @@
+/*
+ * Copyright Elasticsearch B.V. and/or licensed to Elasticsearch B.V. under one
+ * or more contributor license agreements. Licensed under the Elastic License;
+ * you may not use this file except in compliance with the Elastic License.
+ */
+
+import { getPublicUrl } from './';
+
+describe('Enterprise Search URL helper', () => {
+  const httpMock = { get: jest.fn() } as any;
+
+  it('calls and returns the public URL API endpoint', async () => {
+    httpMock.get.mockImplementationOnce(() => ({ publicUrl: 'http://some.vanity.url' }));
+
+    expect(await getPublicUrl(httpMock)).toEqual('http://some.vanity.url');
+  });
+
+  it('strips trailing slashes', async () => {
+    httpMock.get.mockImplementationOnce(() => ({ publicUrl: 'http://trailing.slash/' }));
+
+    expect(await getPublicUrl(httpMock)).toEqual('http://trailing.slash');
+  });
+
+  // For the most part, error logging/handling is done on the server side.
+  // On the front-end, we should simply gracefully fall back to config.host
+  // if we can't fetch a public URL
+  it('falls back to an empty string', async () => {
+    expect(await getPublicUrl(httpMock)).toEqual('');
+  });
+});

--- a/x-pack/plugins/enterprise_search/public/applications/shared/enterprise_search_url/get_enterprise_search_url.ts
+++ b/x-pack/plugins/enterprise_search/public/applications/shared/enterprise_search_url/get_enterprise_search_url.ts
@@ -1,0 +1,27 @@
+/*
+ * Copyright Elasticsearch B.V. and/or licensed to Elasticsearch B.V. under one
+ * or more contributor license agreements. Licensed under the Elastic License;
+ * you may not use this file except in compliance with the Elastic License.
+ */
+
+import { HttpSetup } from 'src/core/public';
+
+/**
+ * On Elastic Cloud, the host URL set in kibana.yml is not necessarily the same
+ * URL we want to send users to in the front-end (e.g. if a vanity URL is set).
+ *
+ * This helper checks a Kibana API endpoint (which has checks an Enterprise
+ * Search internal API endpoint) for the correct public-facing URL to use.
+ */
+export const getPublicUrl = async (http: HttpSetup): Promise<string> => {
+  try {
+    const { publicUrl } = await http.get('/api/enterprise_search/public_url');
+    return stripTrailingSlash(publicUrl);
+  } catch {
+    return '';
+  }
+};
+
+const stripTrailingSlash = (url: string): string => {
+  return url.endsWith('/') ? url.slice(0, -1) : url;
+};

--- a/x-pack/plugins/enterprise_search/public/applications/shared/enterprise_search_url/index.ts
+++ b/x-pack/plugins/enterprise_search/public/applications/shared/enterprise_search_url/index.ts
@@ -1,0 +1,7 @@
+/*
+ * Copyright Elasticsearch B.V. and/or licensed to Elasticsearch B.V. under one
+ * or more contributor license agreements. Licensed under the Elastic License;
+ * you may not use this file except in compliance with the Elastic License.
+ */
+
+export { getPublicUrl } from './get_enterprise_search_url';

--- a/x-pack/plugins/enterprise_search/server/plugin.ts
+++ b/x-pack/plugins/enterprise_search/server/plugin.ts
@@ -21,6 +21,7 @@ import { SecurityPluginSetup } from '../../security/server';
 import { PluginSetupContract as FeaturesPluginSetup } from '../../features/server';
 
 import { checkAccess } from './lib/check_access';
+import { registerPublicUrlRoute } from './routes/enterprise_search/public_url';
 import { registerEnginesRoute } from './routes/app_search/engines';
 import { registerTelemetryRoute } from './routes/app_search/telemetry';
 import { registerTelemetryUsageCollector } from './collectors/app_search/telemetry';
@@ -113,6 +114,7 @@ export class EnterpriseSearchPlugin implements Plugin {
     const router = http.createRouter();
     const dependencies = { router, config, log: this.logger };
 
+    registerPublicUrlRoute(dependencies);
     registerEnginesRoute(dependencies);
 
     /**

--- a/x-pack/plugins/enterprise_search/server/routes/__mocks__/router.mock.ts
+++ b/x-pack/plugins/enterprise_search/server/routes/__mocks__/router.mock.ts
@@ -21,7 +21,7 @@ type payloadType = 'params' | 'query' | 'body';
 
 interface IMockRouterProps {
   method: methodType;
-  payload: payloadType;
+  payload?: payloadType;
 }
 interface IMockRouterRequest {
   body?: object;
@@ -33,7 +33,7 @@ type TMockRouterRequest = KibanaRequest | IMockRouterRequest;
 export class MockRouter {
   public router!: jest.Mocked<IRouter>;
   public method: methodType;
-  public payload: payloadType;
+  public payload?: payloadType;
   public response = httpServerMock.createResponseFactory();
 
   constructor({ method, payload }: IMockRouterProps) {
@@ -58,6 +58,8 @@ export class MockRouter {
    */
 
   public validateRoute = (request: TMockRouterRequest) => {
+    if (!this.payload) throw new Error('Cannot validate wihout a payload type specified.');
+
     const [config] = this.router[this.method].mock.calls[0];
     const validate = config.validate as RouteValidatorConfig<{}, {}, {}>;
 

--- a/x-pack/plugins/enterprise_search/server/routes/enterprise_search/public_url.test.ts
+++ b/x-pack/plugins/enterprise_search/server/routes/enterprise_search/public_url.test.ts
@@ -1,0 +1,54 @@
+/*
+ * Copyright Elasticsearch B.V. and/or licensed to Elasticsearch B.V. under one
+ * or more contributor license agreements. Licensed under the Elastic License;
+ * you may not use this file except in compliance with the Elastic License.
+ */
+
+import { MockRouter } from '../__mocks__/router.mock';
+
+jest.mock('../../lib/enterprise_search_config_api', () => ({
+  callEnterpriseSearchConfigAPI: jest.fn(),
+}));
+import { callEnterpriseSearchConfigAPI } from '../../lib/enterprise_search_config_api';
+
+import { registerPublicUrlRoute } from './public_url';
+
+describe('Enterprise Search Public URL API', () => {
+  const mockRouter = new MockRouter({ method: 'get' });
+
+  beforeEach(() => {
+    jest.clearAllMocks();
+    mockRouter.createRouter();
+
+    registerPublicUrlRoute({
+      router: mockRouter.router,
+      config: {},
+      log: {},
+    } as any);
+  });
+
+  describe('GET /api/enterprise_search/public_url', () => {
+    it('returns a publicUrl', async () => {
+      (callEnterpriseSearchConfigAPI as jest.Mock).mockImplementationOnce(() => {
+        return Promise.resolve({ publicUrl: 'http://some.vanity.url' });
+      });
+
+      await mockRouter.callRoute({});
+
+      expect(mockRouter.response.ok).toHaveBeenCalledWith({
+        body: { publicUrl: 'http://some.vanity.url' },
+        headers: { 'content-type': 'application/json' },
+      });
+    });
+
+    // For the most part, all error logging is handled by callEnterpriseSearchConfigAPI.
+    // This endpoint should mostly just fall back gracefully to an empty string
+    it('falls back to an empty string', async () => {
+      await mockRouter.callRoute({});
+      expect(mockRouter.response.ok).toHaveBeenCalledWith({
+        body: { publicUrl: '' },
+        headers: { 'content-type': 'application/json' },
+      });
+    });
+  });
+});

--- a/x-pack/plugins/enterprise_search/server/routes/enterprise_search/public_url.ts
+++ b/x-pack/plugins/enterprise_search/server/routes/enterprise_search/public_url.ts
@@ -1,0 +1,26 @@
+/*
+ * Copyright Elasticsearch B.V. and/or licensed to Elasticsearch B.V. under one
+ * or more contributor license agreements. Licensed under the Elastic License;
+ * you may not use this file except in compliance with the Elastic License.
+ */
+
+import { IRouteDependencies } from '../../plugin';
+import { callEnterpriseSearchConfigAPI } from '../../lib/enterprise_search_config_api';
+
+export function registerPublicUrlRoute({ router, config, log }: IRouteDependencies) {
+  router.get(
+    {
+      path: '/api/enterprise_search/public_url',
+      validate: false,
+    },
+    async (context, request, response) => {
+      const { publicUrl = '' } =
+        (await callEnterpriseSearchConfigAPI({ request, config, log })) || {};
+
+      return response.ok({
+        body: { publicUrl },
+        headers: { 'content-type': 'application/json' },
+      });
+    }
+  );
+}


### PR DESCRIPTION
## What

This adds the ability to modify our front-end URL links to a "public"/vanity URL. e.g. 

- If `enterpriseSearch.host` is set to `https://cloud.elastic.co/somereallylongid-123456789/` (no idea if this is a legit URL, just an example)
- But Enterprise Search has an internal vanity URL set to `http://vanityurl.com/`
- The public facing-URLs should go to `http://vanityurl.com/as` but the APIs should continue to hit `https://cloud.elastic.co/somereallylongid-123456789/`

## Why

This functionality is mostly needed by Elastic Cloud, which will be setting vanity URLs on top of our Enterprise Search app

⚠️ Note: In theory this means that once the front-end is fully ported over Kibana, we can remove this code, since we won't be generating front-end URL links to Enterprise Search any longer

## How

- The client-side calls a server-side route `/api/enterprise_search/public_url` (unfortunately, I checked with the Kibana team/Josh Dover and the only way to pass data from `server/` to `public/` is via HTTP call 😞)
- The sever-side route calls our new Enterprise Search internal API - `/api/ent/v1/internal/client_config`, which returns an `external_url` field (along with other misc info)
- We pass that back to the client-side to seamlessly store/override the existing `config.host` URL
- NOTE: This call should only ever happen **once** per page load, **not** on every react-router navigation.

## QA

Enterprise Search Setup:
- Have Enterprise Search up and running
- Temporarily mock your local Enterprise Search to return a vanity URL:
    - Open `shared_togo/app/controllers/api/shared_togo/v1/internal/client_config_controller.rb`
    - Change line 34 to `:external_url => 'http://vanityurl.com'`

Kibana:
- Feature testing
    - Go to http://localhost:5601/app/enterprise_search/app_search
    - [x] Confirm that all URLs/buttons to App Search (e.g. "Launch App Search" button in header, "Create an engine" on empty prompt CTA) now all open links to `http://vanityurl.com/as`, not `http://localhost:3002/as`
- Call testing
    - Open your devtools and track XHR calls/open the Network tab
    - Go to http://localhost:5601/app/enterprise_search/app_search/setup_guide
    - [x] Confirm that only one call is made to `http://localhost:5601/api/enterprise_search/public_url`
    - In the Kibana header breadcrumbs, click on "App Search" - it should navigate via React Router (i.e. no hard page load)
    - [x] Confirm that another call to `http://localhost:5601/api/enterprise_search/public_url` was **not** made (you should only see `api/app_search/engines?type=indexed&pageIndex=1` and telemetry